### PR TITLE
Add Laravel 9 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -11,55 +11,15 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [7.1, 7.2, 7.3, 7.4, 8.0]
-        laravel: [5.4.*, 5.5.*, 5.6.*, 5.7.*, 5.8.*, 6.*, 7.*, 8.*, 9.*]
+        php: [8.0, 8.1]
+        laravel: [8.*, 9.*]
         include:
-          - laravel: 5.4.*
-            testbench: 3.4.*
-            phpunit: ~5.7.21
-          - laravel: 5.5.*
-            testbench: 3.5.*
-            phpunit: ~6.0
-          - laravel: 5.6.*
-            testbench: 3.6.*
-            phpunit: ^7.0
-          - laravel: 5.7.*
-            testbench: 3.7.*
-            phpunit: ^7.0
-          - laravel: 5.8.*
-            testbench: 3.8.*
-            phpunit: ^7.5
-          - laravel: 6.*
-            testbench: 4.*
-            phpunit: ^8.0
-          - laravel: 7.*
-            testbench: 5.*
-            phpunit: ^8.4
           - laravel: 8.*
             testbench: 6.*
             phpunit: ^8.5
           - laravel: 9.*
             testbench: 7.*
             phpunit: ^9.0
-        exclude:
-          - laravel: 6.*
-            php: 7.1
-          - laravel: 7.*
-            php: 7.1
-          - laravel: 8.*
-            php: 7.1
-          - laravel: 8.*
-            php: 7.2
-          - laravel: 8.*
-            php: 7.3
-          - laravel: 9.*
-            php: 7.1
-          - laravel: 9.*
-            php: 7.2
-          - laravel: 9.*
-            php: 7.3
-          - laravel: 9.*
-            php: 7.4
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -84,7 +84,7 @@ jobs:
       - name: Execute tests
         run: vendor/bin/phpunit --coverage-clover=coverage.xml
 
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1
-        with:
-          file: ./coverage.xml
+      # - name: Upload coverage to Codecov
+      #   uses: codecov/codecov-action@v1
+      #   with:
+      #     file: ./coverage.xml

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -4,12 +4,11 @@ on: [push, pull_request]
 
 jobs:
   test:
-
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [7.1, 7.2, 7.3, 7.4, 8.0]
-        laravel: [5.4.*, 5.5.*, 5.6.*, 5.7.*, 5.8.*, 6.*, 7.*, 8.*]
+        php: [7.1, 7.2, 7.3, 7.4, 8.0, 8.1]
+        laravel: [5.4.*, 5.5.*, 5.6.*, 5.7.*, 5.8.*, 6.*, 7.*, 8.*, 9.*]
         include:
           - laravel: 5.4.*
             testbench: 3.4.*
@@ -35,6 +34,9 @@ jobs:
           - laravel: 8.*
             testbench: 6.*
             phpunit: ^8.5
+          - laravel: 9.*
+            testbench: 7.*
+            phpunit: ^9.0
         exclude:
           - laravel: 6.*
             php: 7.1
@@ -46,7 +48,14 @@ jobs:
             php: 7.2
           - laravel: 8.*
             php: 7.3
-
+          - laravel: 9.*
+            php: 7.1
+          - laravel: 9.*
+            php: 7.2
+          - laravel: 9.*
+            php: 7.3
+          - laravel: 9.*
+            php: 7.4
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,6 +1,10 @@
 name: "Run Tests"
 
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - master
 
 jobs:
   test:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [7.1, 7.2, 7.3, 7.4, 8.0, 8.1]
+        php: [7.1, 7.2, 7.3, 7.4, 8.0]
         laravel: [5.4.*, 5.5.*, 5.6.*, 5.7.*, 5.8.*, 6.*, 7.*, 8.*, 9.*]
         include:
           - laravel: 5.4.*

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Execute tests
         run: vendor/bin/phpunit --coverage-clover=coverage.xml
 
-      # - name: Upload coverage to Codecov
-      #   uses: codecov/codecov-action@v1
-      #   with:
-      #     file: ./coverage.xml
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v1
+        with:
+          file: ./coverage.xml

--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@
 Serve Laravel Assets from a Content Delivery Network (CDN)
 </strong></p>
 
+> [!IMPORTANT]
+> This repository was forked from [arubacao/asset-cdn](https://github.com/arubacao/asset-cdn) and modified to work with Laravel 9.
+> The original repository is no longer maintained.
+
 ## Introduction
 
 This package lets you **push**, **sync**, **delete** and **serve** assets to/from a CDN of your choice e.g. AWS Cloudfront.  

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,10 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "kylekatarnls/update-helper": true
+        }
     },
     "extra": {
         "laravel": {

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "arubacao/asset-cdn",
+    "name": "accredifysg/asset-cdn",
     "description": "Serve Laravel Assets from a Content Delivery Network (CDN)",
     "keywords": [
         "Laravel",
@@ -7,23 +7,24 @@
         "Content Delivery Network",
         "AWS Cloudfront"
     ],
-    "homepage": "https://github.com/arubacao/asset-cdn",
+    "homepage": "https://github.com/Accredifysg/asset-cdn",
     "license": "MIT",
     "authors": [
         {
-            "name": "Christopher Lass",
-            "homepage": "https://c-lass.com/"
+            "name": "Ryuta Hamasaki",
+            "email": "ryuta.hamasaki@accredify.io",
+            "homepage": "https://accredify.io"
         }
     ],
     "require": {
         "php": "^7.0|^8.0",
-        "laravel/framework": "~5.4|^6.0|^7.0|^8.0"
+        "laravel/framework": "~5.4|^6.0|^7.0|^8.0|^9.0"
     },
     "require-dev": {
-        "league/flysystem-aws-s3-v3": "^1.0",
+        "league/flysystem-aws-s3-v3": "^3.0",
         "mockery/mockery": "^1.0",
-        "orchestra/testbench": "~3.4|^4.0|^5.0|^6.0",
-        "phpunit/phpunit": "~5.7|~6.0|^7.0|^8.0",
+        "orchestra/testbench": "~3.4|^4.0|^5.0|^6.0|^7.0",
+        "phpunit/phpunit": "~5.7|~6.0|^7.0|^8.0|^9.0",
         "spatie/temporary-directory": "^1.1"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "laravel/framework": "~5.4|^6.0|^7.0|^8.0|^9.0"
     },
     "require-dev": {
-        "league/flysystem-aws-s3-v3": "^3.0",
+        "league/flysystem-aws-s3-v3": "^1.0|^3.0",
         "mockery/mockery": "^1.0",
         "orchestra/testbench": "~3.4|^4.0|^5.0|^6.0|^7.0",
         "phpunit/phpunit": "~5.7|~6.0|^7.0|^8.0|^9.0",

--- a/composer.json
+++ b/composer.json
@@ -17,14 +17,14 @@
         }
     ],
     "require": {
-        "php": "^7.0|^8.0",
-        "laravel/framework": "~5.4|^6.0|^7.0|^8.0|^9.0"
+        "php": "^8.0",
+        "laravel/framework": "^8.0|^9.0"
     },
     "require-dev": {
         "league/flysystem-aws-s3-v3": "^1.0|^3.0",
         "mockery/mockery": "^1.0",
-        "orchestra/testbench": "~3.4|^4.0|^5.0|^6.0|^7.0",
-        "phpunit/phpunit": "~5.7|~6.0|^7.0|^8.0|^9.0",
+        "orchestra/testbench": "^6.0|^7.0",
+        "phpunit/phpunit": "^8.0|^9.0",
         "spatie/temporary-directory": "^1.1"
     },
     "autoload": {

--- a/tests/Commands/PushCommandTest.php
+++ b/tests/Commands/PushCommandTest.php
@@ -56,7 +56,7 @@ class PushCommandTest extends TestCase
                     string $name,
                     array $options
                 ) use ($expectedOptions) {
-                    $this->assertArraySubset($expectedOptions, $options);
+                    $this->assertSame($expectedOptions, array_intersect_key($options, $expectedOptions));
 
                     return true;
                 }

--- a/tests/Commands/SyncCommandTest.php
+++ b/tests/Commands/SyncCommandTest.php
@@ -90,14 +90,15 @@ class SyncCommandTest extends TestCase
             [
                 'path' => 'css',
                 'filename' => 'front.css',
-                'base' => __DIR__.'/../testfiles/dummy',
+                'base' => __DIR__ . '/../testfiles/dummy',
             ],
         ]);
 
-        $this->assertNotEquals($expectedFileSize,
+        $this->assertNotEquals(
+            $expectedFileSize,
             Storage::disk('test_filesystem')
                 ->size('css/front.css')
-            );
+        );
 
         $this->setFilesInConfig([
             'include' => [
@@ -115,7 +116,8 @@ class SyncCommandTest extends TestCase
 
         $this->assertFilesExistOnCdnFilesystem($expectedFiles);
 
-        $this->assertEquals($expectedFileSize,
+        $this->assertEquals(
+            $expectedFileSize,
             Storage::disk('test_filesystem')
                 ->size('css/front.css')
         );
@@ -131,11 +133,12 @@ class SyncCommandTest extends TestCase
             [
                 'path' => 'js',
                 'filename' => 'front.app.js',
-                'base' => __DIR__.'/../testfiles/dummy',
+                'base' => __DIR__ . '/../testfiles/dummy',
             ],
         ]);
 
-        $this->assertNotEquals($expectedHash,
+        $this->assertNotEquals(
+            $expectedHash,
             md5(Storage::disk('test_filesystem')
                 ->get('js/front.app.js'))
         );
@@ -156,7 +159,8 @@ class SyncCommandTest extends TestCase
 
         $this->assertFilesExistOnCdnFilesystem($expectedFiles);
 
-        $this->assertEquals($expectedHash,
+        $this->assertEquals(
+            $expectedHash,
             md5(Storage::disk('test_filesystem')
                 ->get('js/front.app.js'))
         );
@@ -166,7 +170,7 @@ class SyncCommandTest extends TestCase
     public function command_syncs_img_file_with_same_size_but_different_hash()
     {
         $src = public_path('img/layout/ph3x2.png');
-        $dummySrc = __DIR__.'/../testfiles/dummy/img/layout/ph3x2.png';
+        $dummySrc = __DIR__ . '/../testfiles/dummy/img/layout/ph3x2.png';
         $expectedHash = md5_file($src);
         $dummyHash = md5_file($dummySrc);
 
@@ -177,11 +181,12 @@ class SyncCommandTest extends TestCase
             [
                 'path' => 'img/layout',
                 'filename' => 'ph3x2.png',
-                'base' => __DIR__.'/../testfiles/dummy',
+                'base' => __DIR__ . '/../testfiles/dummy',
             ],
         ]);
 
-        $this->assertNotEquals($expectedHash,
+        $this->assertNotEquals(
+            $expectedHash,
             md5(Storage::disk('test_filesystem')
                 ->get('img/layout/ph3x2.png'))
         );
@@ -202,7 +207,8 @@ class SyncCommandTest extends TestCase
 
         $this->assertFilesExistOnCdnFilesystem($expectedFiles);
 
-        $this->assertEquals($expectedHash,
+        $this->assertEquals(
+            $expectedHash,
             md5(Storage::disk('test_filesystem')
                 ->get('img/layout/ph3x2.png'))
         );
@@ -238,7 +244,7 @@ class SyncCommandTest extends TestCase
                     string $name,
                     array $options
                 ) use ($expectedOptions) {
-                    $this->assertArraySubset($expectedOptions, $options);
+                    $this->assertSame($expectedOptions, array_intersect_key($options, $expectedOptions));
 
                     return true;
                 }

--- a/tests/Commands/TestCase.php
+++ b/tests/Commands/TestCase.php
@@ -29,7 +29,7 @@ class TestCase extends \Arubacao\AssetCdn\Test\TestCase
         $actualFiles = array_values($actualFiles);
         $expectedFiles = array_values($expectedFiles);
 
-        $this->assertArraySubset($expectedFiles, $actualFiles);
+        $this->assertSame($expectedFiles, array_intersect_key($actualFiles, $expectedFiles));
         $this->assertCount(count($expectedFiles), $actualFiles);
     }
 

--- a/tests/Finder/TestCase.php
+++ b/tests/Finder/TestCase.php
@@ -26,9 +26,7 @@ class TestCase extends \Arubacao\AssetCdn\Test\TestCase
         $actualFiles = array_values($actualFiles);
         $expectedFiles = array_values($expectedFiles);
 
-//        dd($actualFiles);
-
-        $this->assertArraySubset($expectedFiles, $actualFiles);
+        $this->assertSame($expectedFiles, array_intersect_key($actualFiles, $expectedFiles));
         $this->assertCount(count($expectedFiles), $actualFiles);
     }
 }


### PR DESCRIPTION
- Add support for Laravel 9
- Drop support for Laravel 7 and earlier and PHP 7. CI was falling because it was testing too many combinations of PHP and Laravel versions concurrently
- Replace the deprecated PHPUnit method